### PR TITLE
Update 2

### DIFF
--- a/src/audio_core/audio_core.cpp
+++ b/src/audio_core/audio_core.cpp
@@ -23,9 +23,9 @@ static constexpr u64 audio_frame_ticks = 1310252ull; ///< Units: ARM11 cycles
 static void AudioTickCallback(u64 /*userdata*/, int cycles_late) {
     if (DSP::HLE::Tick()) {
         // TODO(merry): Signal all the other interrupts as appropriate.
-        DSP_DSP::SignalPipeInterrupt(DSP::HLE::DspPipe::Audio);
+        Service::DSP_DSP::SignalPipeInterrupt(DSP::HLE::DspPipe::Audio);
         // HACK(merry): Added to prevent regressions. Will remove soon.
-        DSP_DSP::SignalPipeInterrupt(DSP::HLE::DspPipe::Binary);
+        Service::DSP_DSP::SignalPipeInterrupt(DSP::HLE::DspPipe::Binary);
     }
 
     // Reschedule recurrent event

--- a/src/audio_core/hle/pipe.cpp
+++ b/src/audio_core/hle/pipe.cpp
@@ -104,7 +104,7 @@ static void AudioPipeWriteStructAddresses() {
         WriteU16(DspPipe::Audio, addr);
     }
     // Signal that we have data on this pipe.
-    DSP_DSP::SignalPipeInterrupt(DspPipe::Audio);
+    Service::DSP_DSP::SignalPipeInterrupt(DspPipe::Audio);
 }
 
 void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) {

--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "citra/config.h"

--- a/src/citra/citra.rc
+++ b/src/citra/citra.rc
@@ -5,5 +5,5 @@
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-GLFW_ICON               ICON                    "..\\..\\dist\\citra.ico"
+CITRA_ICON              ICON                    "../../dist/citra.ico"
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <atomic>
 #include <condition_variable>
 #include <mutex>

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -23,7 +23,7 @@ class EmuThread : public QThread {
     Q_OBJECT
 
 public:
-    EmuThread(GRenderWindow* render_window);
+    explicit EmuThread(GRenderWindow* render_window);
 
     /**
      * Start emulation (on new thread)

--- a/src/citra_qt/citra-qt.rc
+++ b/src/citra_qt/citra-qt.rc
@@ -5,5 +5,5 @@
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON1               ICON                    "..\\..\\dist\\citra.ico"
+CITRA_ICON              ICON                    "../../dist/citra.ico"
 

--- a/src/citra_qt/debugger/callstack.h
+++ b/src/citra_qt/debugger/callstack.h
@@ -13,7 +13,7 @@ class CallstackWidget : public QDockWidget {
     Q_OBJECT
 
 public:
-    CallstackWidget(QWidget* parent = nullptr);
+    explicit CallstackWidget(QWidget* parent = nullptr);
 
 public slots:
     void OnDebugModeEntered();

--- a/src/citra_qt/debugger/callstack.h
+++ b/src/citra_qt/debugger/callstack.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <QDockWidget>
 #include "ui_callstack.h"
 

--- a/src/citra_qt/debugger/disassembler.h
+++ b/src/citra_qt/debugger/disassembler.h
@@ -17,7 +17,7 @@ class DisassemblerModel : public QAbstractListModel {
     Q_OBJECT
 
 public:
-    DisassemblerModel(QObject* parent);
+    explicit DisassemblerModel(QObject* parent);
 
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/src/citra_qt/debugger/graphics.cpp
+++ b/src/citra_qt/debugger/graphics.cpp
@@ -22,15 +22,15 @@ QVariant GPUCommandStreamItemModel::data(const QModelIndex& index, int role) con
         return QVariant();
 
     int command_index = index.row();
-    const GSP_GPU::Command& command = GetDebugger()->ReadGXCommandHistory(command_index);
+    const Service::GSP::Command& command = GetDebugger()->ReadGXCommandHistory(command_index);
     if (role == Qt::DisplayRole) {
-        std::map<GSP_GPU::CommandId, const char*> command_names = {
-            {GSP_GPU::CommandId::REQUEST_DMA, "REQUEST_DMA"},
-            {GSP_GPU::CommandId::SUBMIT_GPU_CMDLIST, "SUBMIT_GPU_CMDLIST"},
-            {GSP_GPU::CommandId::SET_MEMORY_FILL, "SET_MEMORY_FILL"},
-            {GSP_GPU::CommandId::SET_DISPLAY_TRANSFER, "SET_DISPLAY_TRANSFER"},
-            {GSP_GPU::CommandId::SET_TEXTURE_COPY, "SET_TEXTURE_COPY"},
-            {GSP_GPU::CommandId::CACHE_FLUSH, "CACHE_FLUSH"},
+        std::map<Service::GSP::CommandId, const char*> command_names = {
+            {Service::GSP::CommandId::REQUEST_DMA, "REQUEST_DMA"},
+            {Service::GSP::CommandId::SUBMIT_GPU_CMDLIST, "SUBMIT_GPU_CMDLIST"},
+            {Service::GSP::CommandId::SET_MEMORY_FILL, "SET_MEMORY_FILL"},
+            {Service::GSP::CommandId::SET_DISPLAY_TRANSFER, "SET_DISPLAY_TRANSFER"},
+            {Service::GSP::CommandId::SET_TEXTURE_COPY, "SET_TEXTURE_COPY"},
+            {Service::GSP::CommandId::CACHE_FLUSH, "CACHE_FLUSH"},
         };
         const u32* command_data = reinterpret_cast<const u32*>(&command);
         QString str = QString("%1 %2 %3 %4 %5 %6 %7 %8 %9")

--- a/src/citra_qt/debugger/graphics.h
+++ b/src/citra_qt/debugger/graphics.h
@@ -13,7 +13,7 @@ class GPUCommandStreamItemModel : public QAbstractListModel,
     Q_OBJECT
 
 public:
-    GPUCommandStreamItemModel(QObject* parent);
+    explicit GPUCommandStreamItemModel(QObject* parent);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;

--- a/src/citra_qt/debugger/graphics_breakpoints.h
+++ b/src/citra_qt/debugger/graphics_breakpoints.h
@@ -20,8 +20,8 @@ class GraphicsBreakPointsWidget : public QDockWidget, Pica::DebugContext::BreakP
     using Event = Pica::DebugContext::Event;
 
 public:
-    GraphicsBreakPointsWidget(std::shared_ptr<Pica::DebugContext> debug_context,
-                              QWidget* parent = nullptr);
+    explicit GraphicsBreakPointsWidget(std::shared_ptr<Pica::DebugContext> debug_context,
+                                       QWidget* parent = nullptr);
 
     void OnPicaBreakPointHit(Pica::DebugContext::Event event, void* data) override;
     void OnPicaResume() override;

--- a/src/citra_qt/debugger/graphics_cmdlists.h
+++ b/src/citra_qt/debugger/graphics_cmdlists.h
@@ -20,7 +20,7 @@ public:
         CommandIdRole = Qt::UserRole,
     };
 
-    GPUCommandListModel(QObject* parent);
+    explicit GPUCommandListModel(QObject* parent);
 
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -39,7 +39,7 @@ class GPUCommandListWidget : public QDockWidget {
     Q_OBJECT
 
 public:
-    GPUCommandListWidget(QWidget* parent = nullptr);
+    explicit GPUCommandListWidget(QWidget* parent = nullptr);
 
 public slots:
     void OnToggleTracing();

--- a/src/citra_qt/debugger/graphics_surface.h
+++ b/src/citra_qt/debugger/graphics_surface.h
@@ -18,7 +18,8 @@ class SurfacePicture : public QLabel {
     Q_OBJECT
 
 public:
-    SurfacePicture(QWidget* parent = 0, GraphicsSurfaceWidget* surface_widget = nullptr);
+    explicit SurfacePicture(QWidget* parent = nullptr,
+                            GraphicsSurfaceWidget* surface_widget = nullptr);
     ~SurfacePicture();
 
 protected slots:
@@ -71,8 +72,8 @@ class GraphicsSurfaceWidget : public BreakPointObserverDock {
     static unsigned int NibblesPerPixel(Format format);
 
 public:
-    GraphicsSurfaceWidget(std::shared_ptr<Pica::DebugContext> debug_context,
-                          QWidget* parent = nullptr);
+    explicit GraphicsSurfaceWidget(std::shared_ptr<Pica::DebugContext> debug_context,
+                                   QWidget* parent = nullptr);
     void Pick(int x, int y);
 
 public slots:

--- a/src/citra_qt/debugger/graphics_tracing.h
+++ b/src/citra_qt/debugger/graphics_tracing.h
@@ -12,8 +12,8 @@ class GraphicsTracingWidget : public BreakPointObserverDock {
     Q_OBJECT
 
 public:
-    GraphicsTracingWidget(std::shared_ptr<Pica::DebugContext> debug_context,
-                          QWidget* parent = nullptr);
+    explicit GraphicsTracingWidget(std::shared_ptr<Pica::DebugContext> debug_context,
+                                   QWidget* parent = nullptr);
 
 private slots:
     void StartRecording();

--- a/src/citra_qt/debugger/graphics_vertex_shader.h
+++ b/src/citra_qt/debugger/graphics_vertex_shader.h
@@ -19,7 +19,7 @@ class GraphicsVertexShaderModel : public QAbstractTableModel {
     Q_OBJECT
 
 public:
-    GraphicsVertexShaderModel(GraphicsVertexShaderWidget* parent);
+    explicit GraphicsVertexShaderModel(GraphicsVertexShaderWidget* parent);
 
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/src/citra_qt/debugger/profiler.h
+++ b/src/citra_qt/debugger/profiler.h
@@ -15,7 +15,7 @@ class ProfilerModel : public QAbstractItemModel {
     Q_OBJECT
 
 public:
-    ProfilerModel(QObject* parent);
+    explicit ProfilerModel(QObject* parent);
 
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
@@ -37,7 +37,7 @@ class ProfilerWidget : public QDockWidget {
     Q_OBJECT
 
 public:
-    ProfilerWidget(QWidget* parent = nullptr);
+    explicit ProfilerWidget(QWidget* parent = nullptr);
 
 private slots:
     void setProfilingInfoUpdateEnabled(bool enable);
@@ -53,7 +53,7 @@ class MicroProfileDialog : public QWidget {
     Q_OBJECT
 
 public:
-    MicroProfileDialog(QWidget* parent = nullptr);
+    explicit MicroProfileDialog(QWidget* parent = nullptr);
 
     /// Returns a QAction that can be used to toggle visibility of this dialog.
     QAction* toggleViewAction();

--- a/src/citra_qt/debugger/ramview.h
+++ b/src/citra_qt/debugger/ramview.h
@@ -10,7 +10,7 @@ class GRamView : public QHexEdit {
     Q_OBJECT
 
 public:
-    GRamView(QWidget* parent = nullptr);
+    explicit GRamView(QWidget* parent = nullptr);
 
 public slots:
     void OnCPUStepped();

--- a/src/citra_qt/debugger/ramview.h
+++ b/src/citra_qt/debugger/ramview.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include "qhexedit.h"
 
 class GRamView : public QHexEdit {

--- a/src/citra_qt/debugger/registers.h
+++ b/src/citra_qt/debugger/registers.h
@@ -15,7 +15,7 @@ class RegistersWidget : public QDockWidget {
     Q_OBJECT
 
 public:
-    RegistersWidget(QWidget* parent = nullptr);
+    explicit RegistersWidget(QWidget* parent = nullptr);
 
 public slots:
     void OnDebugModeEntered();

--- a/src/citra_qt/debugger/registers.h
+++ b/src/citra_qt/debugger/registers.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <QDockWidget>
 #include "ui_registers.h"
 

--- a/src/citra_qt/debugger/wait_tree.h
+++ b/src/citra_qt/debugger/wait_tree.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <boost/container/flat_set.hpp>
 
 #include <QAbstractItemModel>

--- a/src/citra_qt/debugger/wait_tree.h
+++ b/src/citra_qt/debugger/wait_tree.h
@@ -51,7 +51,7 @@ private:
 class WaitTreeText : public WaitTreeItem {
     Q_OBJECT
 public:
-    WaitTreeText(const QString& text);
+    explicit WaitTreeText(const QString& text);
     QString GetText() const override;
 
 private:
@@ -67,7 +67,7 @@ public:
 class WaitTreeWaitObject : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    WaitTreeWaitObject(const Kernel::WaitObject& object);
+    explicit WaitTreeWaitObject(const Kernel::WaitObject& object);
     static std::unique_ptr<WaitTreeWaitObject> make(const Kernel::WaitObject& object);
     QString GetText() const override;
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
@@ -94,7 +94,7 @@ private:
 class WaitTreeThread : public WaitTreeWaitObject {
     Q_OBJECT
 public:
-    WaitTreeThread(const Kernel::Thread& thread);
+    explicit WaitTreeThread(const Kernel::Thread& thread);
     QString GetText() const override;
     QColor GetColor() const override;
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
@@ -103,35 +103,37 @@ public:
 class WaitTreeEvent : public WaitTreeWaitObject {
     Q_OBJECT
 public:
-    WaitTreeEvent(const Kernel::Event& object);
+    explicit WaitTreeEvent(const Kernel::Event& object);
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 };
 
 class WaitTreeMutex : public WaitTreeWaitObject {
     Q_OBJECT
 public:
-    WaitTreeMutex(const Kernel::Mutex& object);
+    explicit WaitTreeMutex(const Kernel::Mutex& object);
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 };
 
 class WaitTreeSemaphore : public WaitTreeWaitObject {
     Q_OBJECT
 public:
-    WaitTreeSemaphore(const Kernel::Semaphore& object);
+    explicit WaitTreeSemaphore(const Kernel::Semaphore& object);
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 };
 
 class WaitTreeTimer : public WaitTreeWaitObject {
     Q_OBJECT
 public:
-    WaitTreeTimer(const Kernel::Timer& object);
+    explicit WaitTreeTimer(const Kernel::Timer& object);
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 };
 
 class WaitTreeMutexList : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    WaitTreeMutexList(const boost::container::flat_set<Kernel::SharedPtr<Kernel::Mutex>>& list);
+    explicit WaitTreeMutexList(
+        const boost::container::flat_set<Kernel::SharedPtr<Kernel::Mutex>>& list);
+
     QString GetText() const override;
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 
@@ -142,7 +144,7 @@ private:
 class WaitTreeThreadList : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    WaitTreeThreadList(const std::vector<Kernel::SharedPtr<Kernel::Thread>>& list);
+    explicit WaitTreeThreadList(const std::vector<Kernel::SharedPtr<Kernel::Thread>>& list);
     QString GetText() const override;
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 
@@ -154,7 +156,7 @@ class WaitTreeModel : public QAbstractItemModel {
     Q_OBJECT
 
 public:
-    WaitTreeModel(QObject* parent = nullptr);
+    explicit WaitTreeModel(QObject* parent = nullptr);
 
     QVariant data(const QModelIndex& index, int role) const override;
     QModelIndex index(int row, int column, const QModelIndex& parent) const override;
@@ -173,7 +175,7 @@ class WaitTreeWidget : public QDockWidget {
     Q_OBJECT
 
 public:
-    WaitTreeWidget(QWidget* parent = nullptr);
+    explicit WaitTreeWidget(QWidget* parent = nullptr);
 
 public slots:
     void OnDebugModeEntered();

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -13,7 +13,7 @@
 #include "game_list_p.h"
 #include "ui_settings.h"
 
-GameList::GameList(QWidget* parent) {
+GameList::GameList(QWidget* parent) : QWidget{parent} {
     QVBoxLayout* layout = new QVBoxLayout;
 
     tree_view = new QTreeView;

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -49,7 +49,7 @@ GameList::~GameList() {
     emit ShouldCancelWorker();
 }
 
-void GameList::AddEntry(QList<QStandardItem*> entry_items) {
+void GameList::AddEntry(const QList<QStandardItem*>& entry_items) {
     item_model->invisibleRootItem()->appendRow(entry_items);
 }
 

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -151,6 +151,6 @@ void GameListWorker::run() {
 }
 
 void GameListWorker::Cancel() {
-    disconnect(this, 0, 0, 0);
+    disconnect(this, nullptr, nullptr, nullptr);
     stop_processing = true;
 }

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -34,7 +34,7 @@ public:
     void LoadInterfaceLayout();
 
 public slots:
-    void AddEntry(QList<QStandardItem*> entry_items);
+    void AddEntry(const QList<QStandardItem*>& entry_items);
 
 private slots:
     void ValidateEntry(const QModelIndex& item);

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -33,18 +33,15 @@ public:
     void SaveInterfaceLayout();
     void LoadInterfaceLayout();
 
-public slots:
-    void AddEntry(const QList<QStandardItem*>& entry_items);
-
-private slots:
-    void ValidateEntry(const QModelIndex& item);
-    void DonePopulating();
-
 signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();
 
 private:
+    void AddEntry(const QList<QStandardItem*>& entry_items);
+    void ValidateEntry(const QModelIndex& item);
+    void DonePopulating();
+
     QTreeView* tree_view = nullptr;
     QStandardItemModel* item_model = nullptr;
     GameListWorker* current_worker = nullptr;

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -25,7 +25,7 @@ public:
         COLUMN_COUNT, // Number of columns
     };
 
-    GameList(QWidget* parent = nullptr);
+    explicit GameList(QWidget* parent = nullptr);
     ~GameList() override;
 
     void PopulateAsync(const QString& dir_path, bool deep_scan);

--- a/src/citra_qt/hotkeys.h
+++ b/src/citra_qt/hotkeys.h
@@ -55,7 +55,7 @@ class GHotkeysDialog : public QWidget {
     Q_OBJECT
 
 public:
-    GHotkeysDialog(QWidget* parent = nullptr);
+    explicit GHotkeysDialog(QWidget* parent = nullptr);
 
 private:
     Ui::hotkeys ui;

--- a/src/citra_qt/util/spinbox.h
+++ b/src/citra_qt/util/spinbox.h
@@ -42,7 +42,7 @@ class CSpinBox : public QAbstractSpinBox {
     Q_OBJECT
 
 public:
-    CSpinBox(QWidget* parent = nullptr);
+    explicit CSpinBox(QWidget* parent = nullptr);
 
     void stepBy(int steps) override;
     StepEnabled stepEnabled() const override;

--- a/src/common/bit_set.h
+++ b/src/common/bit_set.h
@@ -16,7 +16,7 @@ namespace Common {
 
 // Helper functions:
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 template <typename T>
 static inline int CountSetBits(T v) {
     // from https://graphics.stanford.edu/~seander/bithacks.html

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -7,7 +7,7 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "common/assert.h"

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -14,7 +14,7 @@
 
 #ifdef _WIN32
 #include <codecvt>
-#include <Windows.h>
+#include <windows.h>
 #include "common/common_funcs.h"
 #else
 #include <iconv.h>

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -6,7 +6,7 @@
 #ifdef __APPLE__
 #include <mach/mach.h>
 #elif defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #else
 #if defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <pthread_np.h>

--- a/src/common/timer.cpp
+++ b/src/common/timer.cpp
@@ -4,7 +4,8 @@
 
 #include <time.h>
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
+// windows.h needs to be included before other windows headers
 #include <mmsystem.h>
 #include <sys/timeb.h>
 #else

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include <dynarmic/dynarmic.h>
 #include "common/assert.h"
 #include "common/microprofile.h"

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -15,8 +15,8 @@
 #include <fcntl.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
-#include <common/x64/abi.h>
+#include <winsock2.h>
+// winsock2.h needs to be included first to prevent winsock.h being included by other includes
 #include <io.h>
 #include <iphlpapi.h>
 #include <ws2tcpip.h>

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -94,13 +94,13 @@ void SoftwareKeyboard::Update() {
 }
 
 void SoftwareKeyboard::DrawScreenKeyboard() {
-    auto bottom_screen = GSP_GPU::GetFrameBufferInfo(0, 1);
+    auto bottom_screen = Service::GSP::GetFrameBufferInfo(0, 1);
     auto info = bottom_screen->framebuffer_info[bottom_screen->index];
 
     // TODO(Subv): Draw the HLE keyboard, for now just zero-fill the framebuffer
     Memory::ZeroBlock(info.address_left, info.stride * 320);
 
-    GSP_GPU::SetBufferSwap(1, info);
+    Service::GSP::SetBufferSwap(1, info);
 }
 
 void SoftwareKeyboard::Finalize() {

--- a/src/core/hle/service/ac_u.cpp
+++ b/src/core/hle/service/ac_u.cpp
@@ -2,14 +2,14 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
+
 #include "common/logging/log.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/service/ac_u.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace AC_U
-
-namespace AC_U {
+namespace Service {
+namespace AC {
 
 struct ACConfig {
     std::array<u8, 0x200> data;
@@ -31,7 +31,7 @@ static Kernel::SharedPtr<Kernel::Event> disconnect_event;
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void CreateDefaultConfig(Service::Interface* self) {
+static void CreateDefaultConfig(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 ac_config_addr = cmd_buff[65];
@@ -56,7 +56,7 @@ static void CreateDefaultConfig(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void ConnectAsync(Service::Interface* self) {
+static void ConnectAsync(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     connect_event = Kernel::g_handle_table.Get<Kernel::Event>(cmd_buff[4]);
@@ -77,7 +77,7 @@ static void ConnectAsync(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void GetConnectResult(Service::Interface* self) {
+static void GetConnectResult(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -94,7 +94,7 @@ static void GetConnectResult(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void CloseAsync(Service::Interface* self) {
+static void CloseAsync(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     if (ac_connected && disconnect_event) {
@@ -120,7 +120,7 @@ static void CloseAsync(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void GetCloseResult(Service::Interface* self) {
+static void GetCloseResult(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -134,7 +134,7 @@ static void GetCloseResult(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : Output connection type, 0 = none, 1 = Old3DS Internet, 2 = New3DS Internet.
  */
-static void GetWifiStatus(Service::Interface* self) {
+static void GetWifiStatus(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     // TODO(purpasmart96): This function is only a stub,
@@ -155,7 +155,7 @@ static void GetWifiStatus(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : Infra Priority
  */
-static void GetInfraPriority(Service::Interface* self) {
+static void GetInfraPriority(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -177,7 +177,7 @@ static void GetInfraPriority(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : Infra Priority
  */
-static void SetRequestEulaVersion(Service::Interface* self) {
+static void SetRequestEulaVersion(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 major = cmd_buff[1] & 0xFF;
@@ -203,7 +203,7 @@ static void SetRequestEulaVersion(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void RegisterDisconnectEvent(Service::Interface* self) {
+static void RegisterDisconnectEvent(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     disconnect_event = Kernel::g_handle_table.Get<Kernel::Event>(cmd_buff[4]);
@@ -221,7 +221,7 @@ static void RegisterDisconnectEvent(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : bool, is connected
  */
-static void IsConnected(Service::Interface* self) {
+static void IsConnected(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -237,7 +237,7 @@ static void IsConnected(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetClientVersion(Service::Interface* self) {
+static void SetClientVersion(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     const u32 version = cmd_buff[1];
@@ -271,10 +271,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00400042, SetClientVersion, "SetClientVersion"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+AC_U::AC_U() {
     Register(FunctionTable);
 
     ac_connected = false;
@@ -284,10 +281,11 @@ Interface::Interface() {
     disconnect_event = nullptr;
 }
 
-Interface::~Interface() {
+AC_U::~AC_U() {
     close_event = nullptr;
     connect_event = nullptr;
     disconnect_event = nullptr;
 }
 
-} // namespace
+} // namespace AC
+} // namespace Service

--- a/src/core/hle/service/ac_u.h
+++ b/src/core/hle/service/ac_u.h
@@ -6,21 +6,18 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace AC_U
+namespace Service {
+namespace AC {
 
-// socket service "ac:u"
-
-namespace AC_U {
-
-class Interface : public Service::Interface {
+class AC_U final : public Interface {
 public:
-    Interface();
-    ~Interface();
+    AC_U();
+    ~AC_U();
 
     std::string GetPortName() const override {
         return "ac:u";
     }
 };
 
-} // namespace
+} // namespace AC
+} // namespace Service

--- a/src/core/hle/service/act_a.cpp
+++ b/src/core/hle/service/act_a.cpp
@@ -4,10 +4,8 @@
 
 #include "core/hle/service/act_a.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace ACT_A
-
-namespace ACT_A {
+namespace Service {
+namespace ACT {
 
 const Interface::FunctionInfo FunctionTable[] = {
     // act:u shared commands
@@ -23,11 +21,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x04230082, nullptr, "ValidateMailAddress"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+ACT_A::ACT_A() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace ACT
+} // namespace Service

--- a/src/core/hle/service/act_a.h
+++ b/src/core/hle/service/act_a.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace ACT_A
+namespace Service {
+namespace ACT {
 
-namespace ACT_A {
-
-class Interface : public Service::Interface {
+class ACT_A final : public Service::Interface {
 public:
-    Interface();
+    ACT_A();
 
     std::string GetPortName() const override {
         return "act:a";
     }
 };
 
-} // namespace
+} // namespace ACT
+} // namespace Service

--- a/src/core/hle/service/act_u.cpp
+++ b/src/core/hle/service/act_u.cpp
@@ -4,10 +4,8 @@
 
 #include "core/hle/service/act_u.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace ACT_U
-
-namespace ACT_U {
+namespace Service {
+namespace ACT {
 
 const Interface::FunctionInfo FunctionTable[] = {
     // clang-format off
@@ -19,11 +17,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     // clang-format on
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+ACT_U::ACT_U() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace ACT
+} // namespace Service

--- a/src/core/hle/service/act_u.h
+++ b/src/core/hle/service/act_u.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace ACT_U
+namespace Service {
+namespace ACT {
 
-namespace ACT_U {
-
-class Interface : public Service::Interface {
+class ACT_U final : public Interface {
 public:
-    Interface();
+    ACT_U();
 
     std::string GetPortName() const override {
         return "act:u";
     }
 };
 
-} // namespace
+} // namespace ACT
+} // namespace Service

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -458,12 +458,16 @@ void GetStartupArgument(Service::Interface* self) {
         return;
     }
 
-    LOG_WARNING(Service_APT, "(stubbed) called startup_argument_type=%u , parameter_size=0x%08x , "
-                             "parameter_value=0x%08x",
-                startup_argument_type, parameter_size, Memory::Read32(cmd_buff[41]));
+    u32 addr = cmd_buff[65];
+    if (addr && parameter_size) {
+        Memory::ZeroBlock(addr, parameter_size);
+    }
+
+    LOG_WARNING(Service_APT, "(stubbed) called startup_argument_type=%u , parameter_size=0x%08x",
+                startup_argument_type, parameter_size);
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = (parameter_size > 0) ? 1 : 0;
+    cmd_buff[2] = 0;
 }
 
 void CheckNew3DSApp(Service::Interface* self) {

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -407,9 +407,11 @@ void CancelLibraryApplet(Service::Interface* self);
  *  Inputs:
  *      1 : Parameter Size (capped to 0x300)
  *      2 : StartupArgumentType
+ *      65 : Output buffer for startup argument
  *  Outputs:
  *      0 : Return header
- *      1 : u8, Exists (0 = does not exist, 1 = exists)
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : u8, Exists (0 = does not exist, 1 = exists)
  */
 void GetStartupArgument(Service::Interface* self);
 

--- a/src/core/hle/service/csnd_snd.cpp
+++ b/src/core/hle/service/csnd_snd.cpp
@@ -9,10 +9,8 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/csnd_snd.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace CSND_SND
-
-namespace CSND_SND {
+namespace Service {
+namespace CSND {
 
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010140, Initialize, "Initialize"},
@@ -29,17 +27,14 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x000C0000, nullptr, "Reset"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+CSND_SND::CSND_SND() {
     Register(FunctionTable);
 }
 
 static Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
 static Kernel::SharedPtr<Kernel::Mutex> mutex = nullptr;
 
-void Initialize(Service::Interface* self) {
+void Initialize(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 size = Common::AlignUp(cmd_buff[1], Memory::PAGE_SIZE);
@@ -56,7 +51,7 @@ void Initialize(Service::Interface* self) {
     cmd_buff[4] = Kernel::g_handle_table.Create(shared_memory).MoveFrom();
 }
 
-void ExecuteType0Commands(Service::Interface* self) {
+void ExecuteType0Commands(Interface* self) {
     u32* const cmd_buff = Kernel::GetCommandBuffer();
     u8* const ptr = shared_memory->GetPointer(cmd_buff[1]);
 
@@ -74,15 +69,16 @@ void ExecuteType0Commands(Service::Interface* self) {
     }
 }
 
-void AcquireSoundChannels(Service::Interface* self) {
+void AcquireSoundChannels(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = 0;
     cmd_buff[2] = 0xFFFFFF00;
 }
 
-void Shutdown(Service::Interface* self) {
+void Shutdown(Interface* self) {
     shared_memory = nullptr;
     mutex = nullptr;
 }
 
-} // namespace
+} // namespace CSND
+} // namespace Service

--- a/src/core/hle/service/csnd_snd.h
+++ b/src/core/hle/service/csnd_snd.h
@@ -6,14 +6,12 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace CSND_SND
+namespace Service {
+namespace CSND {
 
-namespace CSND_SND {
-
-class Interface : public Service::Interface {
+class CSND_SND final : public Interface {
 public:
-    Interface();
+    CSND_SND();
 
     std::string GetPortName() const override {
         return "csnd:SND";
@@ -28,9 +26,10 @@ struct Type0Command {
     u8 parameters[20];
 };
 
-void Initialize(Service::Interface* self);
-void ExecuteType0Commands(Service::Interface* self);
-void AcquireSoundChannels(Service::Interface* self);
-void Shutdown(Service::Interface* self);
+void Initialize(Interface* self);
+void ExecuteType0Commands(Interface* self);
+void AcquireSoundChannels(Interface* self);
+void Shutdown(Interface* self);
 
-} // namespace
+} // namespace CSND
+} // namespace Service

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -12,9 +12,7 @@
 
 using DspPipe = DSP::HLE::DspPipe;
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace DSP_DSP
-
+namespace Service {
 namespace DSP_DSP {
 
 static Kernel::SharedPtr<Kernel::Event> semaphore_event;
@@ -582,4 +580,5 @@ Interface::~Interface() {
     interrupt_events = {};
 }
 
-} // namespace
+} // namespace DSP_DSP
+} // namespace Service

--- a/src/core/hle/service/dsp_dsp.h
+++ b/src/core/hle/service/dsp_dsp.h
@@ -13,12 +13,10 @@ enum class DspPipe;
 }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace DSP_DSP
-
+namespace Service {
 namespace DSP_DSP {
 
-class Interface : public Service::Interface {
+class Interface final : public Service::Interface {
 public:
     Interface();
     ~Interface() override;
@@ -35,3 +33,4 @@ public:
 void SignalPipeInterrupt(DSP::HLE::DspPipe pipe);
 
 } // namespace DSP_DSP
+} // namespace Service

--- a/src/core/hle/service/err_f.cpp
+++ b/src/core/hle/service/err_f.cpp
@@ -13,10 +13,8 @@
 #include "core/hle/result.h"
 #include "core/hle/service/err_f.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace ERR_F
-
-namespace ERR_F {
+namespace Service {
+namespace ERR {
 
 enum class FatalErrType : u32 {
     Generic = 0,
@@ -167,7 +165,7 @@ static void LogGenericInfo(const ErrInfo::ErrInfoCommon& errinfo_common) {
  *       0 : Header code
  *       1 : Result code
  */
-static void ThrowFatalError(Service::Interface* self) {
+static void ThrowFatalError(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     LOG_CRITICAL(Service_ERR, "Fatal error");
@@ -256,11 +254,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     // clang-format on
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+ERR_F::ERR_F() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace ERR
+} // namespace Service

--- a/src/core/hle/service/err_f.h
+++ b/src/core/hle/service/err_f.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace ERR_F
+namespace Service {
+namespace ERR {
 
-namespace ERR_F {
-
-class Interface : public Service::Interface {
+class ERR_F final : public Interface {
 public:
-    Interface();
+    ERR_F();
 
     std::string GetPortName() const override {
         return "err:f";
     }
 };
 
-} // namespace
+} // namespace ERR
+} // namespace Service

--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -18,13 +18,11 @@
 // Main graphics debugger object - TODO: Here is probably not the best place for this
 GraphicsDebugger g_debugger;
 
+namespace Service {
+namespace GSP {
+
 // Beginning address of HW regs
-const static u32 REGS_BEGIN = 0x1EB00000;
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace GSP_GPU
-
-namespace GSP_GPU {
+const u32 REGS_BEGIN = 0x1EB00000;
 
 const ResultCode ERR_GSP_REGS_OUTOFRANGE_OR_MISALIGNED(
     ErrorDescription::OutofRangeOrMisalignedAddress, ErrorModule::GX, ErrorSummary::InvalidArgument,
@@ -179,7 +177,7 @@ static ResultCode WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, VAddr
  *      2 : number of registers to write sequentially
  *      4 : pointer to source data array
  */
-static void WriteHWRegs(Service::Interface* self) {
+static void WriteHWRegs(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 reg_addr = cmd_buff[1];
     u32 size = cmd_buff[2];
@@ -199,7 +197,7 @@ static void WriteHWRegs(Service::Interface* self) {
  *      4 : pointer to source data array
  *      6 : pointer to mask array
  */
-static void WriteHWRegsWithMask(Service::Interface* self) {
+static void WriteHWRegsWithMask(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 reg_addr = cmd_buff[1];
     u32 size = cmd_buff[2];
@@ -211,7 +209,7 @@ static void WriteHWRegsWithMask(Service::Interface* self) {
 }
 
 /// Read a GSP GPU hardware register
-static void ReadHWRegs(Service::Interface* self) {
+static void ReadHWRegs(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 reg_addr = cmd_buff[1];
     u32 size = cmd_buff[2];
@@ -298,7 +296,7 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
  *  Outputs:
  *      1: Result code
  */
-static void SetBufferSwap(Service::Interface* self) {
+static void SetBufferSwap(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 screen_id = cmd_buff[1];
     FrameBufferInfo* fb_info = (FrameBufferInfo*)&cmd_buff[2];
@@ -319,7 +317,7 @@ static void SetBufferSwap(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void FlushDataCache(Service::Interface* self) {
+static void FlushDataCache(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 address = cmd_buff[1];
     u32 size = cmd_buff[2];
@@ -340,7 +338,7 @@ static void FlushDataCache(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetAxiConfigQoSMode(Service::Interface* self) {
+static void SetAxiConfigQoSMode(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 mode = cmd_buff[1];
 
@@ -359,7 +357,7 @@ static void SetAxiConfigQoSMode(Service::Interface* self) {
  *      2 : Thread index into GSP command buffer
  *      4 : Handle to GSP shared memory
  */
-static void RegisterInterruptRelayQueue(Service::Interface* self) {
+static void RegisterInterruptRelayQueue(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 flags = cmd_buff[1];
 
@@ -391,7 +389,7 @@ static void RegisterInterruptRelayQueue(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void UnregisterInterruptRelayQueue(Service::Interface* self) {
+static void UnregisterInterruptRelayQueue(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     g_thread_id = 0;
@@ -592,7 +590,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
  *  Outputs:
  *      1: Result code
  */
-static void SetLcdForceBlack(Service::Interface* self) {
+static void SetLcdForceBlack(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     bool enable_black = cmd_buff[1] != 0;
@@ -609,7 +607,7 @@ static void SetLcdForceBlack(Service::Interface* self) {
 }
 
 /// This triggers handling of the GX command written to the command buffer in shared memory.
-static void TriggerCmdReqQueue(Service::Interface* self) {
+static void TriggerCmdReqQueue(Interface* self) {
     // Iterate through each thread's command queue...
     for (unsigned thread_id = 0; thread_id < 0x4; ++thread_id) {
         CommandBuffer* command_buffer = (CommandBuffer*)GetCommandBuffer(thread_id);
@@ -648,7 +646,7 @@ static void TriggerCmdReqQueue(Service::Interface* self) {
  *      8: Bottom screen framebuffer format
  *      9: Bottom screen framebuffer width
  */
-static void ImportDisplayCaptureInfo(Service::Interface* self) {
+static void ImportDisplayCaptureInfo(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     // TODO(Subv): We're always returning the framebuffer structures for thread_id = 0,
@@ -680,7 +678,7 @@ static void ImportDisplayCaptureInfo(Service::Interface* self) {
  *  Outputs:
  *      1: Result code
  */
-static void AcquireRight(Service::Interface* self) {
+static void AcquireRight(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     gpu_right_acquired = true;
@@ -695,7 +693,7 @@ static void AcquireRight(Service::Interface* self) {
  *  Outputs:
  *      1: Result code
  */
-static void ReleaseRight(Service::Interface* self) {
+static void ReleaseRight(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     gpu_right_acquired = false;
@@ -739,10 +737,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x001F0082, nullptr, "StoreDataCache"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+GSP_GPU::GSP_GPU() {
     Register(FunctionTable);
 
     g_interrupt_event = nullptr;
@@ -757,10 +752,11 @@ Interface::Interface() {
     first_initialization = true;
 }
 
-Interface::~Interface() {
+GSP_GPU::~GSP_GPU() {
     g_interrupt_event = nullptr;
     g_shared_memory = nullptr;
     gpu_right_acquired = false;
 }
 
-} // namespace
+} // namespace GSP
+} // namespace Service

--- a/src/core/hle/service/gsp_gpu.h
+++ b/src/core/hle/service/gsp_gpu.h
@@ -11,10 +11,8 @@
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace GSP_GPU
-
-namespace GSP_GPU {
+namespace Service {
+namespace GSP {
 
 /// GSP interrupt ID
 enum class InterruptId : u8 {
@@ -176,11 +174,10 @@ struct CommandBuffer {
 };
 static_assert(sizeof(CommandBuffer) == 0x200, "CommandBuffer struct has incorrect size");
 
-/// Interface to "srv:" service
-class Interface : public Service::Interface {
+class GSP_GPU final : public Interface {
 public:
-    Interface();
-    ~Interface() override;
+    GSP_GPU();
+    ~GSP_GPU() override;
 
     std::string GetPortName() const override {
         return "gsp::Gpu";
@@ -203,4 +200,6 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info);
  * @returns FramebufferUpdate Information about the specified framebuffer.
  */
 FrameBufferUpdate* GetFrameBufferInfo(u32 thread_id, u32 screen_index);
-} // namespace
+
+} // namespace GSP
+} // namespace Service

--- a/src/core/hle/service/gsp_lcd.cpp
+++ b/src/core/hle/service/gsp_lcd.cpp
@@ -4,10 +4,8 @@
 
 #include "core/hle/service/gsp_lcd.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace GSP_LCD
-
-namespace GSP_LCD {
+namespace Service {
+namespace GSP {
 
 const Interface::FunctionInfo FunctionTable[] = {
     // clang-format off
@@ -23,11 +21,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     // clang-format on
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+GSP_LCD::GSP_LCD() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace GSP
+} // namespace Service

--- a/src/core/hle/service/gsp_lcd.h
+++ b/src/core/hle/service/gsp_lcd.h
@@ -6,19 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace GSP_LCD
+namespace Service {
+namespace GSP {
 
-namespace GSP_LCD {
-
-/// Interface to "gsp::Lcd" service
-class Interface : public Service::Interface {
+class GSP_LCD final : public Interface {
 public:
-    Interface();
+    GSP_LCD();
 
     std::string GetPortName() const override {
         return "gsp::Lcd";
     }
 };
 
-} // namespace
+} // namespace GSP
+} // namespace Service

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -4,10 +4,8 @@
 
 #include "core/hle/service/http_c.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace HTTP_C
-
-namespace HTTP_C {
+namespace Service {
+namespace HTTP {
 
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010044, nullptr, "Initialize"},
@@ -66,11 +64,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00390000, nullptr, "Finalize"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+HTTP_C::HTTP_C() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace HTTP
+} // namespace Service

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace HTTP_C
+namespace Service {
+namespace HTTP {
 
-namespace HTTP_C {
-
-class Interface : public Service::Interface {
+class HTTP_C final : public Interface {
 public:
-    Interface();
+    HTTP_C();
 
     std::string GetPortName() const override {
         return "http:C";
     }
 };
 
-} // namespace
+} // namespace HTTP
+} // namespace Service

--- a/src/core/hle/service/ldr_ro/cro_helper.cpp
+++ b/src/core/hle/service/ldr_ro/cro_helper.cpp
@@ -7,10 +7,8 @@
 #include "common/scope_exit.h"
 #include "core/hle/service/ldr_ro/cro_helper.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace LDR_RO
-
-namespace LDR_RO {
+namespace Service {
+namespace LDR {
 
 static const ResultCode ERROR_BUFFER_TOO_SMALL = // 0xE0E12C1F
     ResultCode(static_cast<ErrorDescription>(31), ErrorModule::RO, ErrorSummary::InvalidArgument,
@@ -1493,4 +1491,5 @@ std::tuple<VAddr, u32> CROHelper::GetExecutablePages() const {
     return std::make_tuple(0, 0);
 }
 
-} // namespace
+} // namespace LDR
+} // namespace Service

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -11,10 +11,8 @@
 #include "core/hle/result.h"
 #include "core/memory.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace LDR_RO
-
-namespace LDR_RO {
+namespace Service {
+namespace LDR {
 
 // GCC versions < 5.0 do not implement std::is_trivially_copyable.
 // Excluding MSVC because it has weird behaviour for std::is_trivially_copyable.
@@ -710,4 +708,5 @@ private:
     ResultCode ApplyExitRelocations(VAddr crs_address);
 };
 
-} // namespace
+} // namespace LDR
+} // namespace Service

--- a/src/core/hle/service/ldr_ro/ldr_ro.cpp
+++ b/src/core/hle/service/ldr_ro/ldr_ro.cpp
@@ -12,10 +12,8 @@
 #include "core/hle/service/ldr_ro/ldr_ro.h"
 #include "core/hle/service/ldr_ro/memory_synchronizer.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace LDR_RO
-
-namespace LDR_RO {
+namespace Service {
+namespace LDR {
 
 static const ResultCode ERROR_ALREADY_INITIALIZED = // 0xD9612FF9
     ResultCode(ErrorDescription::AlreadyInitialized, ErrorModule::RO, ErrorSummary::Internal,
@@ -71,7 +69,7 @@ static bool VerifyBufferState(VAddr buffer_ptr, u32 size) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void Initialize(Service::Interface* self) {
+static void Initialize(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     VAddr crs_buffer_ptr = cmd_buff[1];
     u32 crs_size = cmd_buff[2];
@@ -196,7 +194,7 @@ static void Initialize(Service::Interface* self) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void LoadCRR(Service::Interface* self) {
+static void LoadCRR(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 crr_buffer_ptr = cmd_buff[1];
     u32 crr_size = cmd_buff[2];
@@ -229,7 +227,7 @@ static void LoadCRR(Service::Interface* self) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void UnloadCRR(Service::Interface* self) {
+static void UnloadCRR(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 crr_buffer_ptr = cmd_buff[1];
     u32 descriptor = cmd_buff[2];
@@ -276,7 +274,7 @@ static void UnloadCRR(Service::Interface* self) {
  *      unified one of two, with an additional parameter link_on_load_bug_fix.
  *      There is a dispatcher template below.
  */
-static void LoadCRO(Service::Interface* self, bool link_on_load_bug_fix) {
+static void LoadCRO(Interface* self, bool link_on_load_bug_fix) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     VAddr cro_buffer_ptr = cmd_buff[1];
     VAddr cro_address = cmd_buff[2];
@@ -469,7 +467,7 @@ static void LoadCRO(Service::Interface* self, bool link_on_load_bug_fix) {
 }
 
 template <bool link_on_load_bug_fix>
-static void LoadCRO(Service::Interface* self) {
+static void LoadCRO(Interface* self) {
     LoadCRO(self, link_on_load_bug_fix);
 }
 
@@ -486,7 +484,7 @@ static void LoadCRO(Service::Interface* self) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void UnloadCRO(Service::Interface* self) {
+static void UnloadCRO(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     VAddr cro_address = cmd_buff[1];
     u32 zero = cmd_buff[2];
@@ -580,7 +578,7 @@ static void UnloadCRO(Service::Interface* self) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void LinkCRO(Service::Interface* self) {
+static void LinkCRO(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     VAddr cro_address = cmd_buff[1];
     u32 descriptor = cmd_buff[2];
@@ -642,7 +640,7 @@ static void LinkCRO(Service::Interface* self) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void UnlinkCRO(Service::Interface* self) {
+static void UnlinkCRO(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     VAddr cro_address = cmd_buff[1];
     u32 descriptor = cmd_buff[2];
@@ -704,7 +702,7 @@ static void UnlinkCRO(Service::Interface* self) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void Shutdown(Service::Interface* self) {
+static void Shutdown(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     VAddr crs_buffer_ptr = cmd_buff[1];
     u32 descriptor = cmd_buff[2];
@@ -762,14 +760,12 @@ const Interface::FunctionInfo FunctionTable[] = {
     // clang-format on
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+LDR_RO::LDR_RO() {
     Register(FunctionTable);
 
     loaded_crs = 0;
     memory_synchronizer.Clear();
 }
 
-} // namespace
+} // namespace LDR
+} // namespace Service

--- a/src/core/hle/service/ldr_ro/ldr_ro.h
+++ b/src/core/hle/service/ldr_ro/ldr_ro.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace LDR_RO
+namespace Service {
+namespace LDR {
 
-namespace LDR_RO {
-
-class Interface : public Service::Interface {
+class LDR_RO final : public Interface {
 public:
-    Interface();
+    LDR_RO();
 
     std::string GetPortName() const override {
         return "ldr:ro";
     }
 };
 
-} // namespace
+} // namespace LDR
+} // namespace Service

--- a/src/core/hle/service/ldr_ro/memory_synchronizer.cpp
+++ b/src/core/hle/service/ldr_ro/memory_synchronizer.cpp
@@ -6,10 +6,8 @@
 #include "common/assert.h"
 #include "core/hle/service/ldr_ro/memory_synchronizer.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace LDR_RO
-
-namespace LDR_RO {
+namespace Service {
+namespace LDR {
 
 auto MemorySynchronizer::FindMemoryBlock(VAddr mapping, VAddr original) {
     auto block = std::find_if(memory_blocks.begin(), memory_blocks.end(),
@@ -40,4 +38,5 @@ void MemorySynchronizer::SynchronizeOriginalMemory() {
     }
 }
 
-} // namespace
+} // namespace LDR
+} // namespace Service

--- a/src/core/hle/service/ldr_ro/memory_synchronizer.h
+++ b/src/core/hle/service/ldr_ro/memory_synchronizer.h
@@ -7,10 +7,8 @@
 #include <vector>
 #include "core/memory.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace LDR_RO
-
-namespace LDR_RO {
+namespace Service {
+namespace LDR {
 
 /**
  * This is a work-around before we implement memory aliasing.
@@ -40,4 +38,5 @@ private:
     auto FindMemoryBlock(VAddr mapping, VAddr original);
 };
 
-} // namespace
+} // namespace LDR
+} // namespace Service

--- a/src/core/hle/service/mic_u.cpp
+++ b/src/core/hle/service/mic_u.cpp
@@ -7,10 +7,8 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/mic_u.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace MIC_U
-
-namespace MIC_U {
+namespace Service {
+namespace MIC {
 
 enum class Encoding : u8 {
     PCM8 = 0,
@@ -49,7 +47,7 @@ static bool audio_buffer_loop;
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void MapSharedMem(Service::Interface* self) {
+static void MapSharedMem(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 size = cmd_buff[1];
     Handle mem_handle = cmd_buff[3];
@@ -68,7 +66,7 @@ static void MapSharedMem(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void UnmapSharedMem(Service::Interface* self) {
+static void UnmapSharedMem(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -87,7 +85,7 @@ static void UnmapSharedMem(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void StartSampling(Service::Interface* self) {
+static void StartSampling(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     encoding = static_cast<Encoding>(cmd_buff[1] & 0xFF);
@@ -111,7 +109,7 @@ static void StartSampling(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void AdjustSampling(Service::Interface* self) {
+static void AdjustSampling(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     sample_rate = static_cast<SampleRate>(cmd_buff[1] & 0xFF);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -125,7 +123,7 @@ static void AdjustSampling(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void StopSampling(Service::Interface* self) {
+static void StopSampling(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     is_sampling = false;
@@ -140,7 +138,7 @@ static void StopSampling(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : 0 = sampling, non-zero = sampling
  */
-static void IsSampling(Service::Interface* self) {
+static void IsSampling(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[2] = is_sampling;
@@ -155,7 +153,7 @@ static void IsSampling(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      3 : Event handle
  */
-static void GetBufferFullEvent(Service::Interface* self) {
+static void GetBufferFullEvent(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[3] = Kernel::g_handle_table.Create(buffer_full_event).MoveFrom();
@@ -170,7 +168,7 @@ static void GetBufferFullEvent(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetGain(Service::Interface* self) {
+static void SetGain(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     mic_gain = cmd_buff[1] & 0xFF;
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -185,7 +183,7 @@ static void SetGain(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : Gain
  */
-static void GetGain(Service::Interface* self) {
+static void GetGain(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[2] = mic_gain;
@@ -200,7 +198,7 @@ static void GetGain(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetPower(Service::Interface* self) {
+static void SetPower(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     mic_power = static_cast<bool>(cmd_buff[1] & 0xFF);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -215,7 +213,7 @@ static void SetPower(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : Power
  */
-static void GetPower(Service::Interface* self) {
+static void GetPower(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[2] = mic_power;
@@ -232,7 +230,7 @@ static void GetPower(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetIirFilterMic(Service::Interface* self) {
+static void SetIirFilterMic(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 size = cmd_buff[1];
@@ -250,7 +248,7 @@ static void SetIirFilterMic(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetClamp(Service::Interface* self) {
+static void SetClamp(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     clamp = static_cast<bool>(cmd_buff[1] & 0xFF);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -265,7 +263,7 @@ static void SetClamp(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : Clamp (0 = don't clamp, non-zero = clamp)
  */
-static void GetClamp(Service::Interface* self) {
+static void GetClamp(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[2] = clamp;
@@ -280,7 +278,7 @@ static void GetClamp(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetAllowShellClosed(Service::Interface* self) {
+static void SetAllowShellClosed(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     allow_shell_closed = static_cast<bool>(cmd_buff[1] & 0xFF);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -294,7 +292,7 @@ static void SetAllowShellClosed(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetClientVersion(Service::Interface* self) {
+static void SetClientVersion(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     const u32 version = cmd_buff[1];
@@ -324,10 +322,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00100040, SetClientVersion, "SetClientVersion"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+MIC_U::MIC_U() {
     Register(FunctionTable);
     shared_memory = nullptr;
     buffer_full_event =
@@ -338,9 +333,10 @@ Interface::Interface() {
     clamp = false;
 }
 
-Interface::~Interface() {
+MIC_U::~MIC_U() {
     shared_memory = nullptr;
     buffer_full_event = nullptr;
 }
 
-} // namespace
+} // namespace MIC
+} // namespace Service

--- a/src/core/hle/service/mic_u.h
+++ b/src/core/hle/service/mic_u.h
@@ -6,21 +6,18 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace MIC_U
+namespace Service {
+namespace MIC {
 
-// mic service
-
-namespace MIC_U {
-
-class Interface : public Service::Interface {
+class MIC_U final : public Interface {
 public:
-    Interface();
-    ~Interface();
+    MIC_U();
+    ~MIC_U();
 
     std::string GetPortName() const override {
         return "mic:u";
     }
 };
 
-} // namespace
+} // namespace MIC
+} // namespace Service

--- a/src/core/hle/service/ns_s.cpp
+++ b/src/core/hle/service/ns_s.cpp
@@ -4,10 +4,8 @@
 
 #include "core/hle/service/ns_s.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace NS_S
-
-namespace NS_S {
+namespace Service {
+namespace NS {
 
 const Interface::FunctionInfo FunctionTable[] = {
     {0x000100C0, nullptr, "LaunchFIRM"},
@@ -27,11 +25,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00160000, nullptr, "RebootSystemClean"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+NS_S::NS_S() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace NS
+} // namespace Service

--- a/src/core/hle/service/ns_s.h
+++ b/src/core/hle/service/ns_s.h
@@ -6,19 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace NS_S
+namespace Service {
+namespace NS {
 
-namespace NS_S {
-
-/// Interface to "NS:S" service
-class Interface : public Service::Interface {
+class NS_S final : public Interface {
 public:
-    Interface();
+    NS_S();
 
     std::string GetPortName() const override {
         return "ns:s";
     }
 };
 
-} // namespace
+} // namespace NS
+} // namespace Service

--- a/src/core/hle/service/nwm_uds.cpp
+++ b/src/core/hle/service/nwm_uds.cpp
@@ -7,10 +7,8 @@
 #include "core/hle/kernel/event.h"
 #include "core/hle/service/nwm_uds.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace NWM_UDS
-
-namespace NWM_UDS {
+namespace Service {
+namespace NWM {
 
 static Kernel::SharedPtr<Kernel::Event> handle_event;
 
@@ -22,7 +20,7 @@ static Kernel::SharedPtr<Kernel::Event> handle_event;
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void Shutdown(Service::Interface* self) {
+static void Shutdown(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     // TODO(purpasmart): Verify return header on HW
@@ -50,7 +48,7 @@ static void Shutdown(Service::Interface* self) {
  *      0 : Return header
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void RecvBeaconBroadcastData(Service::Interface* self) {
+static void RecvBeaconBroadcastData(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 out_buffer_size = cmd_buff[1];
     u32 unk1 = cmd_buff[2];
@@ -90,7 +88,7 @@ static void RecvBeaconBroadcastData(Service::Interface* self) {
  *      2 : Value 0
  *      3 : Output handle
  */
-static void InitializeWithVersion(Service::Interface* self) {
+static void InitializeWithVersion(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 unk1 = cmd_buff[1];
     u32 unk2 = cmd_buff[12];
@@ -148,17 +146,15 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00220402, nullptr, "ScanOnConnection"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+NWM_UDS::NWM_UDS() {
     handle_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "NWM_UDS::handle_event");
 
     Register(FunctionTable);
 }
 
-Interface::~Interface() {
+NWM_UDS::~NWM_UDS() {
     handle_event = nullptr;
 }
 
-} // namespace
+} // namespace NWM
+} // namespace Service

--- a/src/core/hle/service/nwm_uds.h
+++ b/src/core/hle/service/nwm_uds.h
@@ -6,21 +6,20 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace NWM_UDS
+// Local-WLAN service
 
-// local-WLAN service
+namespace Service {
+namespace NWM {
 
-namespace NWM_UDS {
-
-class Interface : public Service::Interface {
+class NWM_UDS final : public Interface {
 public:
-    Interface();
-    ~Interface() override;
+    NWM_UDS();
+    ~NWM_UDS() override;
 
     std::string GetPortName() const override {
         return "nwm::UDS";
     }
 };
 
-} // namespace
+} // namespace NWM
+} // namespace Service

--- a/src/core/hle/service/pm_app.cpp
+++ b/src/core/hle/service/pm_app.cpp
@@ -4,10 +4,8 @@
 
 #include "core/hle/service/pm_app.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace PM_APP
-
-namespace PM_APP {
+namespace Service {
+namespace PM {
 
 const Interface::FunctionInfo FunctionTable[] = {
     // clang-format off
@@ -27,11 +25,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     // clang-format on
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+PM_APP::PM_APP() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace PM
+} // namespace Service

--- a/src/core/hle/service/pm_app.h
+++ b/src/core/hle/service/pm_app.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace PM_APP
+namespace Service {
+namespace PM {
 
-namespace PM_APP {
-
-class Interface : public Service::Interface {
+class PM_APP final : public Interface {
 public:
-    Interface();
+    PM_APP();
 
     std::string GetPortName() const override {
         return "pm:app";
     }
 };
 
-} // namespace
+} // namespace PM
+} // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -109,8 +109,8 @@ void AddService(Interface* interface_) {
 
 /// Initialize ServiceManager
 void Init() {
-    AddNamedPort(new SRV::Interface);
-    AddNamedPort(new ERR_F::Interface);
+    AddNamedPort(new SRV::SRV);
+    AddNamedPort(new ERR::ERR_F);
 
     FS::ArchiveInit();
     AM::Init();
@@ -131,22 +131,22 @@ void Init() {
     PTM::Init();
     QTM::Init();
 
-    AddService(new AC_U::Interface);
-    AddService(new ACT_A::Interface);
-    AddService(new ACT_U::Interface);
-    AddService(new CSND_SND::Interface);
+    AddService(new AC::AC_U);
+    AddService(new ACT::ACT_A);
+    AddService(new ACT::ACT_U);
+    AddService(new CSND::CSND_SND);
     AddService(new DSP_DSP::Interface);
-    AddService(new GSP_GPU::Interface);
-    AddService(new GSP_LCD::Interface);
-    AddService(new HTTP_C::Interface);
-    AddService(new LDR_RO::Interface);
-    AddService(new MIC_U::Interface);
-    AddService(new NS_S::Interface);
-    AddService(new NWM_UDS::Interface);
-    AddService(new PM_APP::Interface);
-    AddService(new SOC_U::Interface);
-    AddService(new SSL_C::Interface);
-    AddService(new Y2R_U::Interface);
+    AddService(new GSP::GSP_GPU);
+    AddService(new GSP::GSP_LCD);
+    AddService(new HTTP::HTTP_C);
+    AddService(new LDR::LDR_RO);
+    AddService(new MIC::MIC_U);
+    AddService(new NS::NS_S);
+    AddService(new NWM::NWM_UDS);
+    AddService(new PM::PM_APP);
+    AddService(new SOC::SOC_U);
+    AddService(new SSL::SSL_C);
+    AddService(new Y2R::Y2R_U);
 
     LOG_DEBUG(Service, "initialized OK");
 }

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -53,12 +53,10 @@
 #define closesocket(x) close(x)
 #endif
 
-static const s32 SOCKET_ERROR_VALUE = -1;
+namespace Service {
+namespace SOC {
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace SOC_U
-
-namespace SOC_U {
+const s32 SOCKET_ERROR_VALUE = -1;
 
 /// Holds the translation from system network errors to 3DS network errors
 static const std::unordered_map<int, int> error_map = {{
@@ -339,7 +337,7 @@ static void CleanupSockets() {
     open_sockets.clear();
 }
 
-static void Socket(Service::Interface* self) {
+static void Socket(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 domain = cmd_buffer[1]; // Address family
     u32 type = cmd_buffer[2];
@@ -378,7 +376,7 @@ static void Socket(Service::Interface* self) {
     cmd_buffer[2] = socket_handle;
 }
 
-static void Bind(Service::Interface* self) {
+static void Bind(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     u32 len = cmd_buffer[2];
@@ -406,7 +404,7 @@ static void Bind(Service::Interface* self) {
     cmd_buffer[2] = res;
 }
 
-static void Fcntl(Service::Interface* self) {
+static void Fcntl(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     u32 ctr_cmd = cmd_buffer[2];
@@ -475,7 +473,7 @@ static void Fcntl(Service::Interface* self) {
     }
 }
 
-static void Listen(Service::Interface* self) {
+static void Listen(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     u32 backlog = cmd_buffer[2];
@@ -490,7 +488,7 @@ static void Listen(Service::Interface* self) {
     cmd_buffer[2] = ret;
 }
 
-static void Accept(Service::Interface* self) {
+static void Accept(Interface* self) {
     // TODO(Subv): Calling this function on a blocking socket will block the emu thread,
     // preventing graceful shutdown when closing the emulator, this can be fixed by always
     // performing nonblocking operations and spinlock until the data is available
@@ -518,7 +516,7 @@ static void Accept(Service::Interface* self) {
     cmd_buffer[3] = IPC::StaticBufferDesc(static_cast<u32>(max_addr_len), 0);
 }
 
-static void GetHostId(Service::Interface* self) {
+static void GetHostId(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
 
     char name[128];
@@ -536,7 +534,7 @@ static void GetHostId(Service::Interface* self) {
     freeaddrinfo(res);
 }
 
-static void Close(Service::Interface* self) {
+static void Close(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
 
@@ -553,7 +551,7 @@ static void Close(Service::Interface* self) {
     cmd_buffer[1] = result;
 }
 
-static void SendTo(Service::Interface* self) {
+static void SendTo(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     u32 len = cmd_buffer[2];
@@ -597,7 +595,7 @@ static void SendTo(Service::Interface* self) {
     cmd_buffer[1] = result;
 }
 
-static void RecvFrom(Service::Interface* self) {
+static void RecvFrom(Interface* self) {
     // TODO(Subv): Calling this function on a blocking socket will block the emu thread,
     // preventing graceful shutdown when closing the emulator, this can be fixed by always
     // performing nonblocking operations and spinlock until the data is available
@@ -654,7 +652,7 @@ static void RecvFrom(Service::Interface* self) {
     cmd_buffer[3] = total_received;
 }
 
-static void Poll(Service::Interface* self) {
+static void Poll(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 nfds = cmd_buffer[1];
     int timeout = cmd_buffer[2];
@@ -692,7 +690,7 @@ static void Poll(Service::Interface* self) {
     cmd_buffer[2] = ret;
 }
 
-static void GetSockName(Service::Interface* self) {
+static void GetSockName(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     socklen_t ctr_len = cmd_buffer[2];
@@ -720,7 +718,7 @@ static void GetSockName(Service::Interface* self) {
     cmd_buffer[1] = result;
 }
 
-static void Shutdown(Service::Interface* self) {
+static void Shutdown(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     int how = cmd_buffer[2];
@@ -733,7 +731,7 @@ static void Shutdown(Service::Interface* self) {
     cmd_buffer[1] = result;
 }
 
-static void GetPeerName(Service::Interface* self) {
+static void GetPeerName(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     socklen_t len = cmd_buffer[2];
@@ -761,7 +759,7 @@ static void GetPeerName(Service::Interface* self) {
     cmd_buffer[1] = result;
 }
 
-static void Connect(Service::Interface* self) {
+static void Connect(Interface* self) {
     // TODO(Subv): Calling this function on a blocking socket will block the emu thread,
     // preventing graceful shutdown when closing the emulator, this can be fixed by always
     // performing nonblocking operations and spinlock until the data is available
@@ -790,7 +788,7 @@ static void Connect(Service::Interface* self) {
     cmd_buffer[2] = ret;
 }
 
-static void InitializeSockets(Service::Interface* self) {
+static void InitializeSockets(Interface* self) {
 // TODO(Subv): Implement
 #ifdef _WIN32
     WSADATA data;
@@ -802,7 +800,7 @@ static void InitializeSockets(Service::Interface* self) {
     cmd_buffer[1] = RESULT_SUCCESS.raw;
 }
 
-static void ShutdownSockets(Service::Interface* self) {
+static void ShutdownSockets(Interface* self) {
     // TODO(Subv): Implement
     CleanupSockets();
 
@@ -814,7 +812,7 @@ static void ShutdownSockets(Service::Interface* self) {
     cmd_buffer[1] = 0;
 }
 
-static void GetSockOpt(Service::Interface* self) {
+static void GetSockOpt(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     u32 level = cmd_buffer[2];
@@ -849,7 +847,7 @@ static void GetSockOpt(Service::Interface* self) {
     cmd_buffer[3] = optlen;
 }
 
-static void SetSockOpt(Service::Interface* self) {
+static void SetSockOpt(Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     u32 level = cmd_buffer[2];
@@ -916,18 +914,16 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00230040, nullptr, "AddGlobalSocket"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+SOC_U::SOC_U() {
     Register(FunctionTable);
 }
 
-Interface::~Interface() {
+SOC_U::~SOC_U() {
     CleanupSockets();
 #ifdef _WIN32
     WSACleanup();
 #endif
 }
 
-} // namespace
+} // namespace SOC
+} // namespace Service

--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -7,19 +7,18 @@
 #include <string>
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace SOC_U
+namespace Service {
+namespace SOC {
 
-namespace SOC_U {
-
-class Interface : public Service::Interface {
+class SOC_U final : public Interface {
 public:
-    Interface();
-    ~Interface();
+    SOC_U();
+    ~SOC_U();
 
     std::string GetPortName() const override {
         return "soc:U";
     }
 };
 
-} // namespace
+} // namespace SOC
+} // namespace Service

--- a/src/core/hle/service/srv.cpp
+++ b/src/core/hle/service/srv.cpp
@@ -7,9 +7,7 @@
 #include "core/hle/kernel/event.h"
 #include "core/hle/service/srv.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace SRV
-
+namespace Service {
 namespace SRV {
 
 static Kernel::SharedPtr<Kernel::Event> event_handle;
@@ -23,7 +21,7 @@ static Kernel::SharedPtr<Kernel::Event> event_handle;
  *      0: 0x00010040
  *      1: ResultCode
  */
-static void RegisterClient(Service::Interface* self) {
+static void RegisterClient(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     if (cmd_buff[1] != IPC::CallingPidDesc()) {
@@ -48,7 +46,7 @@ static void RegisterClient(Service::Interface* self) {
  *      2: Translation descriptor: 0x20
  *      3: Handle to semaphore signaled on process notification
  */
-static void EnableNotification(Service::Interface* self) {
+static void EnableNotification(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     // TODO(bunnei): Change to a semaphore once these have been implemented
@@ -73,7 +71,7 @@ static void EnableNotification(Service::Interface* self) {
  *      1: ResultCode
  *      3: Service handle
  */
-static void GetServiceHandle(Service::Interface* self) {
+static void GetServiceHandle(Interface* self) {
     ResultCode res = RESULT_SUCCESS;
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
@@ -99,7 +97,7 @@ static void GetServiceHandle(Service::Interface* self) {
  *      0: 0x00090040
  *      1: ResultCode
  */
-static void Subscribe(Service::Interface* self) {
+static void Subscribe(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 notification_id = cmd_buff[1];
@@ -118,7 +116,7 @@ static void Subscribe(Service::Interface* self) {
  *      0: 0x000A0040
  *      1: ResultCode
  */
-static void Unsubscribe(Service::Interface* self) {
+static void Unsubscribe(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 notification_id = cmd_buff[1];
@@ -138,7 +136,7 @@ static void Unsubscribe(Service::Interface* self) {
  *      0: 0x000C0040
  *      1: ResultCode
  */
-static void PublishToSubscriber(Service::Interface* self) {
+static void PublishToSubscriber(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 notification_id = cmd_buff[1];
@@ -167,16 +165,14 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x000E00C0, nullptr, "IsServiceRegistered"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+SRV::SRV() {
     Register(FunctionTable);
     event_handle = nullptr;
 }
 
-Interface::~Interface() {
+SRV::~SRV() {
     event_handle = nullptr;
 }
 
 } // namespace SRV
+} // namespace Service

--- a/src/core/hle/service/srv.h
+++ b/src/core/hle/service/srv.h
@@ -4,20 +4,19 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace SRV
-
+namespace Service {
 namespace SRV {
 
 /// Interface to "srv:" service
-class Interface : public Service::Interface {
+class SRV final : public Interface {
 public:
-    Interface();
-    ~Interface() override;
+    SRV();
+    ~SRV() override;
 
     std::string GetPortName() const override {
         return "srv:";
     }
 };
 
-} // namespace
+} // namespace SRV
+} // namespace Service

--- a/src/core/hle/service/ssl_c.cpp
+++ b/src/core/hle/service/ssl_c.cpp
@@ -6,15 +6,13 @@
 #include "common/common_types.h"
 #include "core/hle/service/ssl_c.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace SSL_C
-
-namespace SSL_C {
+namespace Service {
+namespace SSL {
 
 // TODO: Implement a proper CSPRNG in the future when actual security is needed
 static std::mt19937 rand_gen;
 
-static void Initialize(Service::Interface* self) {
+static void Initialize(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     // Seed random number generator when the SSL service is initialized
@@ -25,7 +23,7 @@ static void Initialize(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw;
 }
 
-static void GenerateRandomData(Service::Interface* self) {
+static void GenerateRandomData(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 size = cmd_buff[1];
@@ -84,11 +82,9 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x001F0082, nullptr, "ContextInitSharedmem"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+SSL_C::SSL_C() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace SSL_C
+} // namespace Service

--- a/src/core/hle/service/ssl_c.h
+++ b/src/core/hle/service/ssl_c.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace SSL_C
+namespace Service {
+namespace SSL {
 
-namespace SSL_C {
-
-class Interface : public Service::Interface {
+class SSL_C final : public Interface {
 public:
-    Interface();
+    SSL_C();
 
     std::string GetPortName() const override {
         return "ssl:C";
     }
 };
 
-} // namespace
+} // namespace SSL
+} // namespace Service

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -11,10 +11,8 @@
 #include "core/hle/service/y2r_u.h"
 #include "core/hw/y2r.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace Y2R_U
-
-namespace Y2R_U {
+namespace Service {
+namespace Y2R {
 
 struct ConversionParameters {
     InputFormat input_format;
@@ -83,7 +81,7 @@ ResultCode ConversionConfiguration::SetStandardCoefficient(
     return RESULT_SUCCESS;
 }
 
-static void SetInputFormat(Service::Interface* self) {
+static void SetInputFormat(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.input_format = static_cast<InputFormat>(cmd_buff[1]);
@@ -94,7 +92,7 @@ static void SetInputFormat(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called input_format=%hhu", conversion.input_format);
 }
 
-static void GetInputFormat(Service::Interface* self) {
+static void GetInputFormat(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x2, 2, 0);
@@ -104,7 +102,7 @@ static void GetInputFormat(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called input_format=%hhu", conversion.input_format);
 }
 
-static void SetOutputFormat(Service::Interface* self) {
+static void SetOutputFormat(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.output_format = static_cast<OutputFormat>(cmd_buff[1]);
@@ -115,7 +113,7 @@ static void SetOutputFormat(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called output_format=%hhu", conversion.output_format);
 }
 
-static void GetOutputFormat(Service::Interface* self) {
+static void GetOutputFormat(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x4, 2, 0);
@@ -125,7 +123,7 @@ static void GetOutputFormat(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called output_format=%hhu", conversion.output_format);
 }
 
-static void SetRotation(Service::Interface* self) {
+static void SetRotation(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.rotation = static_cast<Rotation>(cmd_buff[1]);
@@ -136,7 +134,7 @@ static void SetRotation(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called rotation=%hhu", conversion.rotation);
 }
 
-static void GetRotation(Service::Interface* self) {
+static void GetRotation(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x6, 2, 0);
@@ -146,7 +144,7 @@ static void GetRotation(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called rotation=%hhu", conversion.rotation);
 }
 
-static void SetBlockAlignment(Service::Interface* self) {
+static void SetBlockAlignment(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.block_alignment = static_cast<BlockAlignment>(cmd_buff[1]);
@@ -157,7 +155,7 @@ static void SetBlockAlignment(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called block_alignment=%hhu", conversion.block_alignment);
 }
 
-static void GetBlockAlignment(Service::Interface* self) {
+static void GetBlockAlignment(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x8, 2, 0);
@@ -174,7 +172,7 @@ static void GetBlockAlignment(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetSpacialDithering(Service::Interface* self) {
+static void SetSpacialDithering(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     spacial_dithering_enabled = cmd_buff[1] & 0xF;
 
@@ -190,7 +188,7 @@ static void SetSpacialDithering(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : u8, 0 = Disabled, 1 = Enabled
  */
-static void GetSpacialDithering(Service::Interface* self) {
+static void GetSpacialDithering(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0xA, 2, 0);
@@ -207,7 +205,7 @@ static void GetSpacialDithering(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetTemporalDithering(Service::Interface* self) {
+static void SetTemporalDithering(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     temporal_dithering_enabled = cmd_buff[1] & 0xF;
 
@@ -223,7 +221,7 @@ static void SetTemporalDithering(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : u8, 0 = Disabled, 1 = Enabled
  */
-static void GetTemporalDithering(Service::Interface* self) {
+static void GetTemporalDithering(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0xC, 2, 0);
@@ -240,7 +238,7 @@ static void GetTemporalDithering(Service::Interface* self) {
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
-static void SetTransferEndInterrupt(Service::Interface* self) {
+static void SetTransferEndInterrupt(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     transfer_end_interrupt_enabled = cmd_buff[1] & 0xf;
 
@@ -256,7 +254,7 @@ static void SetTransferEndInterrupt(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : u8, 0 = Disabled, 1 = Enabled
  */
-static void GetTransferEndInterrupt(Service::Interface* self) {
+static void GetTransferEndInterrupt(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0xE, 2, 0);
@@ -272,7 +270,7 @@ static void GetTransferEndInterrupt(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      3 : The handle of the completion event
  */
-static void GetTransferEndEvent(Service::Interface* self) {
+static void GetTransferEndEvent(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0xF, 2, 0);
@@ -282,7 +280,7 @@ static void GetTransferEndEvent(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called");
 }
 
-static void SetSendingY(Service::Interface* self) {
+static void SetSendingY(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.src_Y.address = cmd_buff[1];
@@ -299,7 +297,7 @@ static void SetSendingY(Service::Interface* self) {
               cmd_buff[6]);
 }
 
-static void SetSendingU(Service::Interface* self) {
+static void SetSendingU(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.src_U.address = cmd_buff[1];
@@ -316,7 +314,7 @@ static void SetSendingU(Service::Interface* self) {
               cmd_buff[6]);
 }
 
-static void SetSendingV(Service::Interface* self) {
+static void SetSendingV(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.src_V.address = cmd_buff[1];
@@ -333,7 +331,7 @@ static void SetSendingV(Service::Interface* self) {
               cmd_buff[6]);
 }
 
-static void SetSendingYUYV(Service::Interface* self) {
+static void SetSendingYUYV(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.src_YUYV.address = cmd_buff[1];
@@ -356,7 +354,7 @@ static void SetSendingYUYV(Service::Interface* self) {
  *       1 : Result of the function, 0 on success, otherwise error code
  *       2 : u8, 0 = Not Finished, 1 = Finished
  */
-static void IsFinishedSendingYuv(Service::Interface* self) {
+static void IsFinishedSendingYuv(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x14, 2, 0);
@@ -372,7 +370,7 @@ static void IsFinishedSendingYuv(Service::Interface* self) {
  *       1 : Result of the function, 0 on success, otherwise error code
  *       2 : u8, 0 = Not Finished, 1 = Finished
  */
-static void IsFinishedSendingY(Service::Interface* self) {
+static void IsFinishedSendingY(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x15, 2, 0);
@@ -388,7 +386,7 @@ static void IsFinishedSendingY(Service::Interface* self) {
  *       1 : Result of the function, 0 on success, otherwise error code
  *       2 : u8, 0 = Not Finished, 1 = Finished
  */
-static void IsFinishedSendingU(Service::Interface* self) {
+static void IsFinishedSendingU(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x16, 2, 0);
@@ -404,7 +402,7 @@ static void IsFinishedSendingU(Service::Interface* self) {
  *       1 : Result of the function, 0 on success, otherwise error code
  *       2 : u8, 0 = Not Finished, 1 = Finished
  */
-static void IsFinishedSendingV(Service::Interface* self) {
+static void IsFinishedSendingV(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x17, 2, 0);
@@ -414,7 +412,7 @@ static void IsFinishedSendingV(Service::Interface* self) {
     LOG_WARNING(Service_Y2R, "(STUBBED) called");
 }
 
-static void SetReceiving(Service::Interface* self) {
+static void SetReceiving(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.dst.address = cmd_buff[1];
@@ -437,7 +435,7 @@ static void SetReceiving(Service::Interface* self) {
  *       1 : Result of the function, 0 on success, otherwise error code
  *       2 : u8, 0 = Not Finished, 1 = Finished
  */
-static void IsFinishedReceiving(Service::Interface* self) {
+static void IsFinishedReceiving(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x19, 2, 0);
@@ -447,7 +445,7 @@ static void IsFinishedReceiving(Service::Interface* self) {
     LOG_WARNING(Service_Y2R, "(STUBBED) called");
 }
 
-static void SetInputLineWidth(Service::Interface* self) {
+static void SetInputLineWidth(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x1A, 1, 0);
@@ -456,7 +454,7 @@ static void SetInputLineWidth(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called input_line_width=%u", cmd_buff[1]);
 }
 
-static void GetInputLineWidth(Service::Interface* self) {
+static void GetInputLineWidth(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x1B, 2, 0);
@@ -466,7 +464,7 @@ static void GetInputLineWidth(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called input_line_width=%u", conversion.input_line_width);
 }
 
-static void SetInputLines(Service::Interface* self) {
+static void SetInputLines(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x1C, 1, 0);
@@ -475,7 +473,7 @@ static void SetInputLines(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called input_lines=%u", cmd_buff[1]);
 }
 
-static void GetInputLines(Service::Interface* self) {
+static void GetInputLines(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x1D, 2, 0);
@@ -485,7 +483,7 @@ static void GetInputLines(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called input_lines=%u", conversion.input_lines);
 }
 
-static void SetCoefficient(Service::Interface* self) {
+static void SetCoefficient(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     const u16* coefficients = reinterpret_cast<const u16*>(&cmd_buff[1]);
@@ -499,7 +497,7 @@ static void SetCoefficient(Service::Interface* self) {
               coefficients[5], coefficients[6], coefficients[7]);
 }
 
-static void GetCoefficient(Service::Interface* self) {
+static void GetCoefficient(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x1F, 5, 0);
@@ -509,7 +507,7 @@ static void GetCoefficient(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called");
 }
 
-static void SetStandardCoefficient(Service::Interface* self) {
+static void SetStandardCoefficient(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 index = cmd_buff[1];
@@ -520,7 +518,7 @@ static void SetStandardCoefficient(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called standard_coefficient=%u", index);
 }
 
-static void GetStandardCoefficient(Service::Interface* self) {
+static void GetStandardCoefficient(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     u32 index = cmd_buff[1];
@@ -539,7 +537,7 @@ static void GetStandardCoefficient(Service::Interface* self) {
     }
 }
 
-static void SetAlpha(Service::Interface* self) {
+static void SetAlpha(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.alpha = cmd_buff[1];
@@ -550,7 +548,7 @@ static void SetAlpha(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called alpha=%hu", conversion.alpha);
 }
 
-static void GetAlpha(Service::Interface* self) {
+static void GetAlpha(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x23, 2, 0);
@@ -560,7 +558,7 @@ static void GetAlpha(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called alpha=%hu", conversion.alpha);
 }
 
-static void SetDitheringWeightParams(Service::Interface* self) {
+static void SetDitheringWeightParams(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     std::memcpy(&dithering_weight_params, &cmd_buff[1], sizeof(DitheringWeightParams));
 
@@ -570,7 +568,7 @@ static void SetDitheringWeightParams(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called");
 }
 
-static void GetDitheringWeightParams(Service::Interface* self) {
+static void GetDitheringWeightParams(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x25, 9, 0);
@@ -580,7 +578,7 @@ static void GetDitheringWeightParams(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called");
 }
 
-static void StartConversion(Service::Interface* self) {
+static void StartConversion(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     // dst_image_size would seem to be perfect for this, but it doesn't include the gap :(
@@ -599,7 +597,7 @@ static void StartConversion(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called");
 }
 
-static void StopConversion(Service::Interface* self) {
+static void StopConversion(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x27, 1, 0);
@@ -614,7 +612,7 @@ static void StopConversion(Service::Interface* self) {
  *      1 : Result of function, 0 on success, otherwise error code
  *      2 : 1 if there's a conversion running, otherwise 0.
  */
-static void IsBusyConversion(Service::Interface* self) {
+static void IsBusyConversion(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x28, 2, 0);
@@ -627,7 +625,7 @@ static void IsBusyConversion(Service::Interface* self) {
 /**
  * Y2R_U::SetPackageParameter service function
  */
-static void SetPackageParameter(Service::Interface* self) {
+static void SetPackageParameter(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     auto params = reinterpret_cast<const ConversionParameters*>(&cmd_buff[1]);
@@ -668,7 +666,7 @@ cleanup:
         params->padding, params->alpha);
 }
 
-static void PingProcess(Service::Interface* self) {
+static void PingProcess(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x2A, 2, 0);
@@ -678,7 +676,7 @@ static void PingProcess(Service::Interface* self) {
     LOG_WARNING(Service_Y2R, "(STUBBED) called");
 }
 
-static void DriverInitialize(Service::Interface* self) {
+static void DriverInitialize(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     conversion.input_format = InputFormat::YUV422_Indiv8;
@@ -704,7 +702,7 @@ static void DriverInitialize(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called");
 }
 
-static void DriverFinalize(Service::Interface* self) {
+static void DriverFinalize(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x2C, 1, 0);
@@ -713,7 +711,7 @@ static void DriverFinalize(Service::Interface* self) {
     LOG_DEBUG(Service_Y2R, "called");
 }
 
-static void GetPackageParameter(Service::Interface* self) {
+static void GetPackageParameter(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[0] = IPC::MakeHeader(0x2D, 4, 0);
@@ -771,18 +769,16 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x002D0000, GetPackageParameter, "GetPackageParameter"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+Y2R_U::Y2R_U() {
     completion_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "Y2R:Completed");
     std::memset(&conversion, 0, sizeof(conversion));
 
     Register(FunctionTable);
 }
 
-Interface::~Interface() {
+Y2R_U::~Y2R_U() {
     completion_event = nullptr;
 }
 
-} // namespace
+} // namespace Y2R
+} // namespace Service

--- a/src/core/hle/service/y2r_u.h
+++ b/src/core/hle/service/y2r_u.h
@@ -10,10 +10,8 @@
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace Y2R_U
-
-namespace Y2R_U {
+namespace Service {
+namespace Y2R {
 
 enum class InputFormat : u8 {
     /// 8-bit input, with YUV components in separate planes and 4:2:2 subsampling.
@@ -127,14 +125,15 @@ struct DitheringWeightParams {
     u16 w3_xOdd_yOdd;
 };
 
-class Interface : public Service::Interface {
+class Y2R_U final : public Interface {
 public:
-    Interface();
-    ~Interface() override;
+    Y2R_U();
+    ~Y2R_U() override;
 
     std::string GetPortName() const override {
         return "y2r:u";
     }
 };
 
-} // namespace
+} // namespace Y2R
+} // namespace Service

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -430,9 +430,9 @@ inline void Write(u32 addr, const T data) {
             // TODO: hwtest this
             if (config.GetStartAddress() != 0) {
                 if (!is_second_filler) {
-                    GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PSC0);
+                    Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PSC0);
                 } else {
-                    GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PSC1);
+                    Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PSC1);
                 }
             }
 
@@ -473,7 +473,7 @@ inline void Write(u32 addr, const T data) {
             }
 
             g_regs.display_transfer_config.trigger = 0;
-            GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PPF);
+            Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PPF);
         }
         break;
     }
@@ -548,8 +548,8 @@ static void VBlankCallback(u64 userdata, int cycles_late) {
     // screen, or if both use the same interrupts and these two instead determine the
     // beginning and end of the VBlank period. If needed, split the interrupt firing into
     // two different intervals.
-    GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PDC0);
-    GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PDC1);
+    Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PDC0);
+    Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PDC1);
 
     // Check for user input updates
     Service::HID::Update();

--- a/src/core/hw/y2r.cpp
+++ b/src/core/hw/y2r.cpp
@@ -18,7 +18,7 @@
 namespace HW {
 namespace Y2R {
 
-using namespace Y2R_U;
+using namespace Service::Y2R;
 
 static const size_t MAX_TILES = 1024 / 8;
 static const size_t TILE_SIZE = 8 * 8;

--- a/src/core/hw/y2r.h
+++ b/src/core/hw/y2r.h
@@ -2,13 +2,16 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-namespace Y2R_U {
+#pragma once
+
+namespace Service {
+namespace Y2R {
 struct ConversionConfiguration;
+}
 }
 
 namespace HW {
 namespace Y2R {
-
-void PerformConversion(Y2R_U::ConversionConfiguration& cvt);
+void PerformConversion(Service::Y2R::ConversionConfiguration& cvt);
 }
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,6 +13,6 @@ include_directories(../../externals/catch/single_include/)
 
 add_executable(tests ${SRCS} ${HEADERS})
 target_link_libraries(tests core video_core audio_core common)
-target_link_libraries(tests ${PLATFORM_LIBRARIES})
+target_link_libraries(tests ${PLATFORM_LIBRARIES} Threads::Threads)
 
 add_test(NAME tests COMMAND $<TARGET_FILE:tests>)

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -68,7 +68,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     switch (id) {
     // Trigger IRQ
     case PICA_REG_INDEX(trigger_irq):
-        GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::P3D);
+        Service::GSP::SignalInterrupt(Service::GSP::InterruptId::P3D);
         break;
 
     case PICA_REG_INDEX_WORKAROUND(triangle_topology, 0x25E):

--- a/src/video_core/gpu_debugger.h
+++ b/src/video_core/gpu_debugger.h
@@ -28,7 +28,8 @@ public:
         * @note All methods in this class are called from the GSP thread
         */
         virtual void GXCommandProcessed(int total_command_count) {
-            const GSP_GPU::Command& cmd = observed->ReadGXCommandHistory(total_command_count - 1);
+            const Service::GSP::Command& cmd =
+                observed->ReadGXCommandHistory(total_command_count - 1);
             LOG_TRACE(Debug_GPU, "Received command: id=%x", (int)cmd.id.Value());
         }
 
@@ -48,16 +49,16 @@ public:
             return;
 
         gx_command_history.emplace_back();
-        GSP_GPU::Command& cmd = gx_command_history.back();
+        Service::GSP::Command& cmd = gx_command_history.back();
 
-        memcpy(&cmd, command_data, sizeof(GSP_GPU::Command));
+        memcpy(&cmd, command_data, sizeof(Service::GSP::Command));
 
         ForEachObserver([this](DebuggerObserver* observer) {
             observer->GXCommandProcessed(static_cast<int>(this->gx_command_history.size()));
         });
     }
 
-    const GSP_GPU::Command& ReadGXCommandHistory(int index) const {
+    const Service::GSP::Command& ReadGXCommandHistory(int index) const {
         // TODO: Is this thread-safe?
         return gx_command_history[index];
     }
@@ -80,5 +81,5 @@ private:
 
     std::vector<DebuggerObserver*> observers;
 
-    std::vector<GSP_GPU::Command> gx_command_history;
+    std::vector<Service::GSP::Command> gx_command_history;
 };


### PR DESCRIPTION
Support mingw cross-compile
Unify Windows ICON resource name
gdbstub: Remove unused include
tests: add missing libcore dependency after 75ee2f8
Add all services to the Service namespace
graphics_cmdlists: Make LoadImage internally linked
graphics_cmdlists: Make LoadTexture and TextureInfoWidget src argumen…
graphics_cmdlists: Get rid of an unused variableCore: Add a forgotten #include <cstring> for graphics_cmdlists: Get rid of variable shadowing
Merge pull request #2300 from lioncash/qt
game_list: Pass the parent constructor argument to the QWidget base c…
game_list: Use QT5's new event connection syntax
game_list: Replace 0 literals with nullptr
game_list: Make the AddEntry argument a const reference
game_list: Make the constructor explicit
game_list: Make slots private functions
citra-qt: Add missing #pragma once directives
citra-qt: Make constructors explicit where applicableAPT::GetStartupArgument: force clear startup argumentMerge pull request #2154 from mailwl/apt-getstartupargument
Merge pull request #2267 from JayFoxRox/fix-mingw-cc
Merge pull request #2275 from jbeich/pthread 